### PR TITLE
[Archive] Refactored 'now' to 'timestamp' as per tariq's comment in previous PR.

### DIFF
--- a/backend/app/routers/orders.py
+++ b/backend/app/routers/orders.py
@@ -15,7 +15,7 @@ def create_order(order_request: CreateOrderRequest) -> CreateOrderResponse:
     """This is the endpoint for creating an order. It generates a notification when an order is created. key endpoint for SR1. Updated in SR2 as it now stores in memory.
     """
     order_id = str(uuid4())     #Generates a unique order ID using uuid4.
-    now = datetime.now(timezone.utc)     #records tiem wfor when order is created/updated/delivered
+    timestamp = datetime.now(timezone.utc)     #records tiem wfor when order is created/updated/delivered
     
     order = CreateOrderResponse(
         order_id = order_id,
@@ -23,8 +23,8 @@ def create_order(order_request: CreateOrderRequest) -> CreateOrderResponse:
         restaurant_id = order_request.restaurant_id,
         items = order_request.items,
         status = "Created",
-        created_at = now,
-        updated_at = now,
+        created_at = timestamp,
+        updated_at = timestamp,
         delivered_at = None
     )
     
@@ -49,13 +49,13 @@ def update_order_status(order_id: str, status_request: OrderStatusUpdateRequest)
     if old_status == new_status:
         raise HTTPException(status_code = 400, detail = "Order status remains unchanged.")     
     
-    now = datetime.now(timezone.utc)
+    timestamp = datetime.now(timezone.utc)
     
     order.status = new_status     #Update the order status in the in-memory store.
-    order.updated_at = now
+    order.updated_at = timestamp
     
     if new_status =="Delivered":
-        order.delivered_at = now
+        order.delivered_at = timestamp
         
     orders_store[order_id] = order     #Save the updated order back to the in-memory store.
     


### PR DESCRIPTION
Summary:
This PR refactors the timestamp variable naming in the orders router to improve readability and clarity. The change addresses review feedback from Tariq in the previous Feature 9 SR1 Past Order History PR.

Changes Made:
- Renamed the variable now to timestamp in orders.py
- No functional behavior was modified. The change only improves code readability and maintainability.